### PR TITLE
Fixup case of being run as cargo subcommand

### DIFF
--- a/ci/selftest.sh
+++ b/ci/selftest.sh
@@ -26,6 +26,12 @@ verify_no_windows
 rm vendor -rf
 echo "ok linux only"
 
+echo "Verifying linux as subcommand"
+cargo vendor-filterer --platform=x86_64-unknown-linux-gnu
+verify_no_windows
+rm vendor -rf
+echo "ok linux only subcommand"
+
 # Default
 cargo-vendor-filterer
 test $(stat --printf="%s" vendor/winapi/src/lib.rs) != 0


### PR DESCRIPTION
Right now cargo passes us our own subcommand name as an extra
argument, which overlaps with us accepting a path.  Special
case undoing this.

It'd be better if cargo set an environment variable we could
use to detect this.