### PR TITLE
main: Use `eprintln!` for logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -558,7 +558,7 @@ fn run() -> Result<()> {
         .unwrap_or_default();
     let mut expanded_platforms = None;
     if have_platform_filters {
-        println!("Gathering metadata for platforms");
+        eprintln!("Gathering metadata for platforms");
         let target_list = get_target_list()?;
         let target_list: Vec<(&str, ParsedPlatform)> = target_list
             .iter()


### PR DESCRIPTION
We need to log to stderr for compatibility because users expect to be able to redirect the output of `cargo vendor` to a file as it generates a cargo config file.