### PR TITLE
Add `--prefix=vendor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ All of these options have corresponding CLI flags; see `cargo vendor-filterer --
 You can also provide `--format=tar.zstd` to output a reproducible tar archive
 compressed via zstd; the default filename will be `vendor.tar.zstd`.  Similarly
 there is `--format=tar.gz` for gzip, and `--format=tar` to output an uncompressed tar archive, which you
-can compress however you like.
+can compress however you like.  It's also strongly recommended to use `--prefix=vendor`
+which has less surprising behavior when unpacked in e.g. a home directory.  For example,
+`--prefix=vendor --format=tar.zstd` together.
 
 This option requires:
 

--- a/ci/selftest.sh
+++ b/ci/selftest.sh
@@ -43,9 +43,16 @@ echo "ok linux only subcommand"
 echo "Verifying linux + output to tar zstd"
 cargo vendor-filterer --platform=x86_64-unknown-linux-gnu --format=tar.zstd mycrate-5.2.7.tar.zstd
 zstdcat mycrate-5.2.7.tar.zstd | tar tf - > out.txt
-grep -qF './anyhow' out.txt
+grep -qEe '^./anyhow' out.txt
 rm -v mycrate-5.2.7.tar.zstd out.txt
 echo "ok linux + output to tar"
+
+echo "Verifying linux + output to --prefix=vendor tar zstd"
+cargo vendor-filterer --platform=x86_64-unknown-linux-gnu --prefix=vendor --format=tar.zstd mycrate-5.2.7.tar.zstd
+zstdcat mycrate-5.2.7.tar.zstd | tar tf - > out.txt
+grep -qEe '^./vendor/anyhow' out.txt
+rm -v mycrate-5.2.7.tar.zstd out.txt
+echo "ok linux + output to tar prefixed"
 
 echo "Verifying linux + output to tar"
 cargo vendor-filterer --platform=x86_64-unknown-linux-gnu --format=tar


### PR DESCRIPTION
Our current tar default puts everything at the toplevel,
which is in retrospect surprising given a more standard
practice of including the `vendor/` directory.

For backwards compatibility, keep things as is, but
add a `--prefix=` option which allows configuring this.

Closes: https://github.com/coreos/cargo-vendor-filterer/issues/27

