### PR TITLE
Support vendored-openssl feature same way as cargo does

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "111.24.0+1.1.1s"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +295,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ either = "1.7.0"
 [dependencies.clap]
 features = ["derive"]
 version = "3.2"
+
+[features]
+vendored-openssl = ["openssl/vendored"]


### PR DESCRIPTION
Some platforms might not have openssl installed and would prefer to compile it statically from source.

Cargo provides ``vendored-openssl`` feature to do so - https://github.com/rust-lang/cargo/blame/master/README.md#L42

This PR adds the same feature to cargo-vendor-filterer