### PR TITLE
Fix the bug in checksum file parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ const OFFLINE: &str = "--offline";
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 struct CargoChecksums {
     files: BTreeMap<String, String>,
-    package: String,
+    package: Option<String>,
 }
 
 /// The minimal bits of Cargo.toml we need.
@@ -774,6 +774,29 @@ fn test_parse_config() {
     let filter = json!({ "exclude-crate-paths": [ { "name": "hex", "exclude": "benches" }, { "name": "curl", "exclude": "curl" } ]});
     let r: VendorFilter = serde_json::from_value(filter).unwrap();
     assert_eq!(r.exclude_crate_paths.unwrap().len(), 2);
+}
+
+#[test]
+fn test_parse_checksums() {
+    use serde_json::json;
+
+    let valid = vec![
+        json!({
+          "files": {
+            "src/lib.rs": "af7f3c1dc4a7612f3519b812f8d6f9298f0f8af2e999ee3a23e6e9a5ddce5d75",
+          },
+          "package": null
+        }),
+        json!({
+          "files": {
+            "src/lib.rs": "af7f3c1dc4a7612f3519b812f8d6f9298f0f8af2e999ee3a23e6e9a5ddce5d75",
+          },
+          "package": "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+        }),
+    ];
+    for case in valid {
+        let _: CargoChecksums = serde_json::from_value(case).unwrap();
+    }
 }
 
 #[test]


### PR DESCRIPTION
It is possible to add the following to the Cargo.toml file:
```toml
[dependencies]
tracing-oslog = { git = "https://github.com/kgrech/tracing-oslog", branch = "zero_byte_fix" }
```

In this case ``.cargo-checksum.json`` will look similar to this:
```json
{
  "files": {
    ".editorconfig": "97449e38427d3efc434009cb1ae1942b56daf7b28a942484cb196d94f015b200",
    ".rustfmt.toml": "113bab55bd151637aa8aad2e0f6de79596d99a82d2e24449d198f6606e6b97ed",
    "Cargo.toml": "c74d0e88d99e379665046b4ba7b8a90218f7993280e6c30869f8e283a16f0684",
    "LICENSE.md": "b36ff589a7b586161394980ac056831e3795e7390270c9be98bb2fa85829646d",
    "README.md": "541e4e5e5c8ac8f5ee4982cc828ac6864bad3e6343e9d9ca324ae7824639df63",
    "build.rs": "3cb1a3c31663e69a5331d3a00ffed50b048c85d7fe8c5fb94dc2a87c9f82a125",
    "src/ffi.rs": "d9dde313263113f9883a1ef6eb1a3f71b8366199125284d9dd7489729fc0e861",
    "src/lib.rs": "af7f3c1dc4a7612f3519b812f8d6f9298f0f8af2e999ee3a23e6e9a5ddce5d75",
    "src/logger.rs": "e54218ee849b13046647f367a6064bbdce97fc22214105c7e39067cf7bc9be08",
    "src/stub.rs": "0fee8535f7f41a56207138af674e23747052191a64156aa97c1786c049f9f5f8",
    "src/visitor.rs": "dabe10d3299b69a0c7ecf35bd1a3fd0a375e5f9bf009f8b22b0b4516212dff85",
    "wrapper.c": "1b5f198a96432e182673ad51ed8cf70974f6a57477672a8afb3872523ae0286d",
    "wrapper.h": "347451ee2239759635a5ff8ccd4b738f37877261b5f9db76abd06b319593dc1b"
  },
  "package": null
}
```

Note that the package could be set to null.

It looks like we do not use it (yet), so just marked it optional and added a unit test