### PR TITLE
Do not filter against crates io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.idea
 /target

--- a/src/main.rs
+++ b/src/main.rs
@@ -624,13 +624,8 @@ fn run() -> Result<()> {
                 continue;
             }
         }
-        // Also skip anything not from crates.io
-        if pkg
-            .source
-            .as_ref()
-            .filter(|source| source.is_crates_io())
-            .is_none()
-        {
+        // Also skip anything local
+        if pkg.source.as_ref().is_none() {
             eprintln!("Skipping {name}");
             continue;
         }


### PR DESCRIPTION
This is how my ``Cargo.toml`` looks like:

```
[package]
name = "my_package"
version = "0.1.0"
edition = "2021"

[dependencies]
thiserror = "1.0.30"
tracing = "0.1"
# Fix for https://github.com/Absolucy/tracing-oslog/pull/3
tracing-oslog = { git = "https://github.com/kgrech/tracing-oslog", branch = "main" }
tracing-core = "0.1"
tracing-subscriber = "0.3"

[dev-dependencies]
libc = "0.2"
```

You can see that ``tracing-oslog`` is not fetched from crates-io, but it is fetch from github. I would sill like to vendor it so that I can build my project without connection to internet.

However right now it is not vendored because of the ``.filter(|source| source.is_crates_io())`` line.

I am making an assumption that the idea of this if is not to vendor local dependencies. However if it is a local dependency, then ``source`` for it is already ``None`` and there is no need to have a filter on top of it.

My assumption could be very well wrong. I can imagine the situation where some crates are pulled from local corporate git system and some are pulled from the internet. For such case, skipping ``.filter(|source| source.is_crates_io())`` makes more sense, but it still looks far from perfect to me as it would fail as soon as you would like to make a fork of some github package on github.

If the intention was to support the second case, would not it be better idea to have allowlist and blocklist support for the source strings in form of regular expressions? Or faster alternative could to make filtering configurable by passing  something like ``--skip-non-crates-io``
