### PR TITLE
main: Honor workspace metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ exclude-crate-paths = [ { name = "curl-sys", exclude = "curl" },
                       ]
 ```
 
+For workspaces, use the corresponding [workspace metadata](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-metadata-table)
+key `workspace.metadata.vendor-filter`.
+
 ## Available options for for `package.metadata.vendor-filter` in Cargo.toml
 
 - `platforms`: List of rustc target triples; this is the same values accepted by

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,9 +319,11 @@ fn gather_config(args: &Args) -> Result<Option<VendorFilter>> {
     let meta = meta
         .exec()
         .context("Executing cargo metadata (first run)")?;
-    meta.root_package()
-        .and_then(|r| VendorFilter::parse_json(&r.metadata).transpose())
-        .transpose()
+    if let Some(root) = meta.root_package() {
+        VendorFilter::parse_json(&root.metadata)
+    } else {
+        VendorFilter::parse_json(&meta.workspace_metadata)
+    }
 }
 
 /// Given a crate, remove matching files/directories in excludes.


### PR DESCRIPTION
I'd missed that this exists earlier.  This allows configuring vendoring for full workspaces too.

Closes: https://github.com/coreos/cargo-vendor-filterer/issues/41