### PR TITLE
Create tempdir in target basedir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -540,7 +540,8 @@ fn run() -> Result<()> {
 
     let tempdir = match args.format {
         OutputTarget::Tar | OutputTarget::TarGzip | OutputTarget::TarZstd => {
-            Some(tempfile::tempdir_in(".")?)
+            let target_basedir = args.path.as_ref().and_then(|p| p.parent());
+            Some(tempfile::tempdir_in(target_basedir.unwrap_or(".".into()))?)
         }
         OutputTarget::Dir => None,
     };


### PR DESCRIPTION
If we create a `vendor/` directory in many git repositories, it might not be `.gitignored` and hence may cause the IDE to try to monitor all the files.

Instead, if one does `cargo vendor-filterer --format=tar.zstd target/vendor.tar.zstd` as encourged by the docs, we now create the temporary directory in `target` which will be gitignored *and* also automatically cleaned up with `cargo clean`.