### PR TITLE
 Use `tar` and `flate2` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anstream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +106,7 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "either",
+ "flate2",
  "hex",
  "once_cell",
  "openssl",
@@ -107,8 +114,10 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
+ "tar",
  "tempfile",
  "toml",
+ "walkdir",
 ]
 
 [[package]]
@@ -193,6 +202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +264,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -361,6 +401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +495,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -472,6 +530,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -564,6 +631,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,7 +649,7 @@ checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
 ]
@@ -665,6 +743,47 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -797,3 +916,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,16 @@ camino = "1.0"
 cargo-lock = "8"
 cargo_metadata = "0.11.3"
 clap = { version = "4.1", features = ["derive", "wrap_help"] }
+flate2 = "1.0"
 hex = "0.4"
 toml = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.80"
 tempfile = "3.3.0"
 smallvec = "1.9.0"
+tar = "0.4.38"
 either = "1.7.0"
+walkdir = "2.3.3"
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = "0.10.40"

--- a/README.md
+++ b/README.md
@@ -64,13 +64,11 @@ can compress however you like.  It's also strongly recommended to use `--prefix=
 which has less surprising behavior when unpacked in e.g. a home directory.  For example,
 `--prefix=vendor --format=tar.zstd` together.
 
-This option requires:
+This option requires `SOURCE_DATE_EPOCH` set in the environment, or an external `git` and the working directory must be a git repository.
 
- - An external GNU `tar` program
- - An external `gzip` or `zstd` program (for `--format=tar.gz` and `--format=tar.zstd` respectively)
- - `SOURCE_DATE_EPOCH` set in the environment, or an external `git` and the working directory must be a git repository
+With `--format=tar.zstd`, this currently requires an external `zstd` binary.
 
-This uses the suggested code from https://reproducible-builds.org/docs/archives/
+This uses the suggested logic from https://reproducible-builds.org/docs/archives/
 to output a reproducible archive; in other words, another process/tool
 can also perform a `git clone` of your project and regenerate the vendor
-tarball to verify it.
+tarball using the same version of `cargo vendor-filterer` to verify it.

--- a/tests/vendor_filterer/format.rs
+++ b/tests/vendor_filterer/format.rs
@@ -24,19 +24,23 @@ fn basic_tar_test(format: VendorFormat) {
         ..Default::default()
     })
     .unwrap();
+    if !output.status.success() {
+        let _ = std::io::copy(
+            &mut std::io::Cursor::new(output.stderr),
+            &mut std::io::stderr().lock(),
+        );
+    }
     assert!(output.status.success());
     assert!(test_folder.exists());
     assert!(test_folder.is_file());
 }
 
 #[test]
-#[cfg(not(windows))]
 fn tar() {
     basic_tar_test(VendorFormat::Tar);
 }
 
 #[test]
-#[cfg(not(windows))]
 fn tar_gz() {
     basic_tar_test(VendorFormat::TarGz);
 }


### PR DESCRIPTION
This gives us support for `--format=tar` and `--format=tar.gz`
on all platforms without an external binary.

For now, `zstd` compression requires an external binary because
the Rust crate still requires an external shared library, which
will be painful for Windows users.

I think this will be OK for MacOS users though since they're likely
to be using homebrew.

It may make sense to have a feature flag for use of external binaries.

---

