### PR TITLE
ci: Also test on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,12 @@ jobs:
         with:
           name: cargo-vendor-filterer
           path: target/debug/cargo-vendor-filterer
-  build-test-windows:
-    runs-on: windows-latest
+  build-test-other:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
We should run the same places as `cargo`.