### PR TITLE
main: Warn about unknown keys in `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "serde",
+ "serde_ignored",
  "serde_json",
  "sha2",
  "smallvec",
@@ -583,6 +584,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94eb4a4087ba8bdf14a9208ac44fddbf55c01a6195f7edfc511ddaff6cae45a6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ smallvec = "1.9.0"
 tar = "0.4.38"
 either = "1.7.0"
 walkdir = "2.3.3"
+serde_ignored = "0.1.7"
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = "0.10.40"

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,13 @@ impl VendorFilter {
         } else {
             return Ok(None);
         };
-        let v: Self = serde_json::from_value(meta.clone())?;
+        let mut unused = std::collections::BTreeSet::new();
+        let v: Self = serde_ignored::deserialize(meta.clone(), |path| {
+            unused.insert(path.to_string());
+        })?;
+        for k in unused {
+            eprintln!("warning: Unknown key {k} in metadata.{CONFIG_KEY}")
+        }
         Ok(Some(v))
     }
 


### PR DESCRIPTION
This will help us know in the future if we add more keys like `tier = "2"` but the user is using a too old binary.