### PR TITLE
Correctly handle filtered-out latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       matrix:
         repos: 
           - "nushell/nushell@0.73.0"
+          - "containers/netavark@v1.8.0"
     steps:
       - name: Download binary
         uses: actions/download-artifact@v2
@@ -92,6 +93,8 @@ jobs:
         with:
           repository: ${{ env.repo }}
           ref: ${{ env.tag }}
+      # For netavark
+      - run: sudo apt install protobuf-compiler
       - run: mkdir -p .cargo && cargo-vendor-filterer --platform x86_64-unknown-linux-gnu --all-features true > .cargo/config.toml
       # This runs without networking, verifying we're building using vendored deps
       - run: rm ~/.cargo/{registry,git} -rf && unshare -Umn cargo check --offline


### PR DESCRIPTION
Basically, in the case that there are two versions of a crate:

- foo-1
- foo-2

`cargo vendor` will write directories named:

- `vendor/foo-1`
- `vendor/foo` (meaning `foo-2`)

We weren't handling the case where the *newer* version of these was filtered out.

To correctly handle this, we need to always gather an unfiltered view to know what `cargo vendor` will do, and then build up a mapping from package IDs to that name.

Closes: https://github.com/coreos/cargo-vendor-filterer/issues/75