### PR TITLE
Support regular files in exclude-crate-paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ tier = "2"
 all-features = true
 exclude-crate-paths = [ { name = "curl-sys", exclude = "curl" },
                         { name = "libz-sys", exclude = "src/zlib" },
+                        { name = "libz-sys", exclude = "src/smoke.c" },
                         { name = "libz-sys", exclude = "src/zlib-ng" },
                       ]
 ```

--- a/tests/vendor_filterer/toml.rs
+++ b/tests/vendor_filterer/toml.rs
@@ -42,9 +42,10 @@ fn metadata() {
 
         [dependencies]
         hex = "0.4"
+        libz-sys = "1.1.16"
 
         [package.metadata.vendor-filter]
-        exclude-crate-paths = [ { name = "hex", exclude = "benches" } ]
+        exclude-crate-paths = [ { name = "hex", exclude = "benches" }, { name = "libz-sys", exclude = "src/smoke.c" } ]
     "#,
     )
     .unwrap();
@@ -56,6 +57,12 @@ fn metadata() {
         ..Default::default()
     })
     .unwrap();
+    if !output.status.success() {
+        let _ = std::io::copy(
+            &mut std::io::Cursor::new(&output.stderr),
+            &mut std::io::stderr(),
+        );
+    }
     assert!(output.status.success());
     let hex = output_folder.join("hex");
     assert!(hex.exists());


### PR DESCRIPTION
I want to exclude `src/smoke.c` from `libz-sys` specifically, as part of a larger goal of supporting filtering out `.c` files for example.