### PR TITLE
feat: support a wildcard in exclude crate paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
@@ -34,7 +34,7 @@ jobs:
       - name: Install
         run: cargo install --path . --debug
       - name: Upload binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cargo-vendor-filterer
           path: target/debug/cargo-vendor-filterer
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Cache Dependencies
         uses: Swatinem/rust-cache@v2
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ env.ACTIONS_LINTS_TOOLCHAIN }}
@@ -87,11 +87,11 @@ jobs:
             args: "-F deps-serde"
     steps:
       - name: Download binary
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: cargo-vendor-filterer
       - run: sudo install -m 0755 cargo-vendor-filterer /usr/bin
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: ${{ matrix.repo }}
           ref: ${{ matrix.tag }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /target
+/vendor

--- a/README.md
+++ b/README.md
@@ -7,28 +7,28 @@ for example.
 
 More information: https://github.com/rust-lang/cargo/issues/7058
 
-# Generating a vendor/ directory with filtering
+## Generating a vendor/ directory with filtering
 
 Here's a basic example which filters out all crates that don't target Linux;
 for example this will drop out crates like `winapi-x86_64-pc-windows-gnu` and
 `core-foundation` that are Windows or MacOS only.
 
-```
+```sh
 $ cargo vendor-filterer --platform=x86_64-unknown-linux-gnu
 ```
 
 You may instead want to filter by tiers:
 
-```
+```sh
 $ cargo vendor-filterer --tier=2
 ```
 
 Currently this will drop out crates such as `redox_syscall`.
 
 You can also declaratively specify the desired vendor configuration via the [Cargo metadata](https://doc.rust-lang.org/cargo/reference/manifest.html#the-metadata-table)
-key `package.metadata.vendor-filter`.  In this example, we include only tier 1 and 2 Linux platforms, and additionally remove some vendored C sources:
+key `package.metadata.vendor-filter`.  In this example, we include only tier 1 and 2 Linux platforms, and additionally remove some vendored C sources and `tests` folders from all crates:
 
-```
+```toml
 [package.metadata.vendor-filter]
 platforms = ["*-unknown-linux-gnu"]
 tier = "2"
@@ -36,13 +36,14 @@ all-features = true
 exclude-crate-paths = [ { name = "curl-sys", exclude = "curl" },
                         { name = "libz-sys", exclude = "src/zlib" },
                         { name = "libz-sys", exclude = "src/zlib-ng" },
+                        { name = "*", exclude = "tests" },
                       ]
 ```
 
 For workspaces, use the corresponding [workspace metadata](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-metadata-table)
 key `workspace.metadata.vendor-filter`.
 
-## Available options for for `package.metadata.vendor-filter` in Cargo.toml
+### Available options for for `package.metadata.vendor-filter` in Cargo.toml
 
 - `platforms`: List of rustc target triples; this is the same values accepted by
   e.g. `cargo metadata --filter-platform`.  You can specify multiple values,
@@ -52,10 +53,11 @@ key `workspace.metadata.vendor-filter`.
 - `exclude-crate-paths`: Remove files and directories from target crates.  A key
   use case for this is removing the vendored copy of C libraries embedded in
   crates like `libz-sys`, when you only want to support dynamically linking.
+  `*` wildcard removes the folder from all creates (typical use case for `tests` folder).
 
 All of these options have corresponding CLI flags; see `cargo vendor-filterer --help`.
 
-# Generating reproducible vendor tarballs
+## Generating reproducible vendor tarballs
 
 You can also provide `--format=tar.zstd` to output a reproducible tar archive
 compressed via zstd; the default filename will be `vendor.tar.zstd`.  Similarly

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,13 +148,14 @@ struct Args {
 
     /// Remove files/subdirectories in crates that match an exact path.
     ///
-    /// The format is "CRATENAME#PATH".  CRATENAME is the name of a crate (without
-    /// a version included).  PATH must be a relative path, and can name a regular
-    /// file, symbolic link or a directory.
+    /// The format is "CRATENAME#PATH". CRATENAME is the name of a crate (without
+    /// a version included) or "*" as a wildcard for all crates. PATH must be a
+    /// relative path, and can name a regular file, symbolic link or a directory.
     ///
     /// If the filename matches a directory, it and all its contents will be removed.
     /// For example, `curl-sys#curl` will remove the vendored libcurl C sources
     /// from the `curl-sys` crate.
+    /// For example, `*#tests` will remove tests folder from all crates.
     ///
     /// Nonexistent paths will emit a warning, but are not currently an error.
     #[arg(long)]
@@ -712,8 +713,11 @@ fn delete_unreferenced_packages(
             assert!(unreferenced.insert(name.to_string()));
         }
 
-        if let Some(excludes) = excludes.get(name) {
-            process_excludes(&pbuf, name, excludes)?;
+        if let Some(crate_excludes) = excludes.get(name) {
+            process_excludes(&pbuf, name, crate_excludes)?;
+        }
+        if let Some(generic_excludes) = excludes.get("*") {
+            process_excludes(&pbuf, name, generic_excludes)?;
         }
 
         let r = pbuf.pop();

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,6 @@ struct Args {
     tier: Option<tiers::Tier>,
 
     /// Remove files/subdirectories in crates that match an exact path.
-    ///
     /// The format is "CRATENAME#PATH". CRATENAME is the name of a crate (without
     /// a version included) or "*" as a wildcard for all crates. PATH must be a
     /// relative path, and can name a regular file, symbolic link or a directory.

--- a/tests/vendor_filterer/exclude.rs
+++ b/tests/vendor_filterer/exclude.rs
@@ -7,12 +7,14 @@ fn linux_multiple_platforms() {
     let output = vendor(VendorOptions {
         output: Some(&test_folder),
         platforms: Some(&["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]),
-        exclude_crate_paths: Some(&["hex#benches"]),
+        exclude_crate_paths: Some(&["hex#benches", "*#tests"]),
         ..Default::default()
     })
     .unwrap();
     assert!(output.status.success());
     verify_no_windows(&test_folder);
     test_folder.push("hex/benches");
+    assert!(!test_folder.exists());
+    test_folder.push("../tests");
     assert!(!test_folder.exists());
 }


### PR DESCRIPTION
Add a wildcard option `*` to the existing parameter `--exclude-crate-path` adding a possibility to excluded folders from all crates.

A typical use case is to remove folders `tests`. 

Background:
- the Rust book recommends using this folder for test code: <https://doc.rust-lang.org/book/ch11-03-test-organization.html>
- I do not expect to have a conflict with actual crate name, because there is currently no crate named `*` and even though it is not strictly against [Rust naming conventions](https://github.com/rust-lang/rfcs/blob/master/text/0430-finalizing-naming-conventions.md), creating a new crate called `*` is against the rule of using words to name things and such a name would be too short (1 character only)

Closes https://github.com/coreos/cargo-vendor-filterer/issues/86