### PR TITLE
Always generate + override `[lib]` for filtered crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub const RESPECT_SOURCE_CONFIG: &str = "--respect-source-config";
 pub const VERSIONED_DIRS: &str = "--versioned-dirs";
 /// The package entry
 pub const MANIFEST_KEY_PACKAGE: &str = "package";
+/// The well-known cargo target for a library
+pub const LIB: &str = "lib";
 /// Extra targets which we need to remove because Cargo validates them and will
 /// error out when we've replaced the library with a stub.
 pub const UNWANTED_MANIFEST_KEYS: &[&str] = &["bin", "example", "test", "bench"];


### PR DESCRIPTION
The core way this project works for filtered crates is to replace them with a "stub" that only has an empty `src/lib.rs`. When processing the manifest previously, we didn't override the `lib` section that might have been present. Usually this worked because of autodiscovery.

But in the corner case that arose recently in cxx where there was a `bin`-only crate as a build dependency, things broke because we dropped the `bin` section but didn't add a `lib`.

Now arguably, there's a bug in `cargo` here because it dropped the dependency in `cargo metadata` but still checks it in `cargo build`.

But anyways it's clearly correct here for us to have a canonical `lib` section always (whether it was present or not in the filtered crate) so do that.

Closes: https://github.com/coreos/cargo-vendor-filterer/issues/111