### PR TITLE
Use `sha2` crate for SHA-256 by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -692,9 +692,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -718,18 +718,18 @@ dependencies = [
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.5.1+3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -781,9 +781,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "proc-macro2"
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,6 @@ checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
 dependencies = [
  "filetime",
  "libc",
- "xattr",
 ]
 
 [[package]]
@@ -1281,17 +1280,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "xattr"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
-dependencies = [
- "libc",
- "linux-raw-sys",
- "rustix",
-]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,14 @@ either = "1.7.0"
 walkdir = "2.3.3"
 serde_ignored = "0.1.7"
 glob = "0.3.2"
-
-[target.'cfg(not(windows))'.dependencies]
-openssl = "0.10.40"
-
-[target.'cfg(windows)'.dependencies]
-sha2 = "0.10"
+sha2 = { version = "0.10", optional = true }
+openssl = { version = "0.10.40", optional = true }
 
 [features]
+default = ["sha-rs"]
 vendored-openssl = ["openssl/vendored"]
+sha-rs = ["dep:sha2"]
+openssl = ["dep:openssl"]
 
 [dev-dependencies]
 once_cell = "1.17.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.3.0"
 smallvec = "1.9.0"
-tar = "0.4.38"
+tar = { version = "0.4.38", default-features = false }
 either = "1.7.0"
 walkdir = "2.3.3"
 serde_ignored = "0.1.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,16 +246,13 @@ fn filter_manifest(manifest: &mut toml::Value) {
 /// Compute the SHA-256 digest of the buffer and return the result in hexadecimal format
 fn sha256_hexdigest(buf: &[u8]) -> Result<String> {
     // NOTE: Keep this in sync with the copy in the tests
-    #[cfg(not(windows))]
+    #[cfg(feature = "openssl")]
     {
         let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), buf)?;
         Ok(hex::encode(digest))
     }
-    #[cfg(windows)]
+    #[cfg(not(feature = "openssl"))]
     {
-        // This is a pure-Rust implementation which avoids the openssl dependency on Windows.
-        // However, it may make sense here to add something like native-tls to the ecosystem
-        // except for sha digests?  On Windows I'm sure there's a core crypto library for this.
         use sha2::Digest;
         let digest = sha2::Sha256::digest(buf);
         Ok(hex::encode(digest))

--- a/tests/vendor_filterer/format.rs
+++ b/tests/vendor_filterer/format.rs
@@ -16,25 +16,24 @@ fn folder() {
     assert!(test_folder.is_dir());
 }
 
+#[cfg(test)]
 /// Compute the SHA-256 digest of the buffer and return the result in hexadecimal format
 fn sha256_hexdigest(buf: &[u8]) -> Result<String> {
     // NOTE: Keep this in sync with the copy in the main binary
-    #[cfg(not(windows))]
+    #[cfg(feature = "openssl")]
     {
         let digest = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), buf)?;
         Ok(hex::encode(digest))
     }
-    #[cfg(windows)]
+    #[cfg(not(feature = "openssl"))]
     {
-        // This is a pure-Rust implementation which avoids the openssl dependency on Windows.
-        // However, it may make sense here to add something like native-tls to the ecosystem
-        // except for sha digests?  On Windows I'm sure there's a core crypto library for this.
         use sha2::Digest;
         let digest = sha2::Sha256::digest(buf);
         Ok(hex::encode(digest))
     }
 }
 
+#[cfg(test)]
 fn basic_tar_test(format: VendorFormat) {
     let (_td, mut test_folder) = tempdir().unwrap();
     test_folder.push(format!("vendor.{format}"));


### PR DESCRIPTION
Add `sha-rs` and `openssl` features and use the sha2 crate for SHA-256 by default. Avoiding openssl dependency can be occasionally very convenient.