### PR TITLE
feat: support glob patterns in exclude-crate-paths (#122)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "clap",
  "either",
  "flate2",
+ "glob",
  "hex",
  "once_cell",
  "openssl",
@@ -437,6 +438,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tar = "0.4.38"
 either = "1.7.0"
 walkdir = "2.3.3"
 serde_ignored = "0.1.7"
+glob = "0.3.2"
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = "0.10.40"

--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ all-features = true
 keep-dep-kinds = "no-dev"
 exclude-crate-paths = [ { name = "curl-sys", exclude = "curl" },
                         { name = "libz-sys", exclude = "src/zlib" },
-                        { name = "libz-sys", exclude = "src/smoke.c" },
+                        { name = "libz-sys", exclude = "src/*.c" },
                         { name = "libz-sys", exclude = "src/zlib-ng" },
+                        { name = "ring", exclude = "pregenerated/*.o" },
                         { name = "*", exclude = "tests" },
+                        { name = "*", exclude = "*.md" },
                       ]
 ```
 
@@ -66,6 +68,7 @@ key `workspace.metadata.vendor-filter`.
   use case for this is removing the vendored copy of C libraries embedded in
   crates like `libz-sys`, when you only want to support dynamically linking.
   `*` wildcard removes the folder from all creates (typical use case for `tests` folder).
+  Supports glob patterns like `*.o`, `src/*.c`, or `**/*.a` for pattern-based exclusions.
 
 All of these options have corresponding CLI flags; see `cargo vendor-filterer --help`.
 

--- a/tests/vendor_filterer/exclude.rs
+++ b/tests/vendor_filterer/exclude.rs
@@ -38,3 +38,34 @@ fn windows_with_dep_kind_filter_normal() {
     test_folder.push("../openssl/examples"); // openssl removed because defined only for non-windows
     assert!(!test_folder.exists());
 }
+
+#[test]
+#[serial_test::parallel]
+fn exclude_with_glob_patterns() {
+    let (_td, mut test_folder) = tempdir().unwrap();
+    test_folder.push("vendor");
+    let output = vendor(VendorOptions {
+        output: Some(&test_folder),
+        platforms: Some(&["x86_64-unknown-linux-gnu"]),
+        exclude_crate_paths: Some(&["hex#*.md", "*#benches", "libz-sys#src/*.c"]),
+        ..Default::default()
+    })
+    .unwrap();
+    assert!(output.status.success());
+    let hex_dir = test_folder.join("hex");
+    assert!(hex_dir.exists());
+    assert!(!hex_dir.join("README.md").exists());
+    assert!(!hex_dir.join("CHANGELOG.md").exists());
+    assert!(!hex_dir.join("benches").exists());
+    // Check that .c files were removed from libz-sys if it exists
+    let libz_sys_dir = test_folder.join("libz-sys");
+    if libz_sys_dir.exists() {
+        let src_dir = libz_sys_dir.join("src");
+        if src_dir.exists() {
+            for entry in src_dir.read_dir_utf8().unwrap() {
+                let entry = entry.unwrap();
+                assert!(entry.path().extension() != Some("c"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds glob pattern support to the `exclude` field in `exclude-crate-paths`. 

Now you can exclude files by pattern instead of just exact names:

```toml
exclude-crate-paths = [
    { name = "ring", exclude = "pregenerated/*.o" },
    { name = "*", exclude = "tests" },
    { name = "openssl-sys", exclude = "**/*.a" }
]
```

Helpful in removing build artefacts, platform-specific binaries, and reducing vendor directory size without having to list every single file.
Backwards compatible - existing exact path exclusions continue to work unchanged.
Fixes #122