### PR TITLE
Avoid potential infinite loop in project_root()

### DIFF
--- a/tests/vendor_filterer/common.rs
+++ b/tests/vendor_filterer/common.rs
@@ -21,7 +21,9 @@ pub(crate) fn project_root() -> Result<Utf8PathBuf> {
         if found_lock_file {
             return Ok(path);
         }
-        path.pop();
+        if !path.pop() {
+            break;
+        }
     }
     bail!(io::Error::from(io::ErrorKind::NotFound))
 }


### PR DESCRIPTION
This fixes an issue where `project_root()` falls into an infinite loop if it reaches the root directory without having found the `Cargo.lock` file. This doesn't come up when running `cargo test` in the usual way, since the `Cargo.lock` file will always be there in the expected location. But it's possible to run into this when running tests in a different way, for example using distro packaging tools.