### PR TITLE
Allow current dir customization in tests

### DIFF
--- a/tests/vendor_filterer/common.rs
+++ b/tests/vendor_filterer/common.rs
@@ -60,7 +60,7 @@ impl fmt::Display for VendorFormat {
 }
 
 #[derive(Default)]
-pub(crate) struct VendorOptions<'a, 'b, 'c, 'd, 'e> {
+pub(crate) struct VendorOptions<'a, 'b, 'c, 'd, 'e, 'f> {
     pub output: Option<&'a Utf8Path>,
     pub platforms: Option<&'b [&'b str]>,
     pub tier: Option<&'static str>,
@@ -70,6 +70,7 @@ pub(crate) struct VendorOptions<'a, 'b, 'c, 'd, 'e> {
     pub sync: Vec<&'e Utf8Path>,
     pub versioned_dirs: bool,
     pub keep_dep_kinds: Option<&'static str>,
+    pub current_dir: Option<&'f Utf8Path>,
 }
 
 /// Run a vendoring process
@@ -83,7 +84,7 @@ pub(crate) fn vendor(options: VendorOptions) -> Result<Output> {
     let mut program = build_root()?;
     program.push(format!("cargo-{SELF_NAME}"));
     let mut cmd = Command::new(&program);
-    cmd.current_dir(project_root()?).arg(SELF_NAME);
+    cmd.current_dir(options.current_dir.unwrap_or(project_root()?.as_path())).arg(SELF_NAME);
     if let Some(platforms) = options.platforms {
         cmd.args(platforms.iter().map(|&p| format!("--platform={p}")));
     }

--- a/tests/vendor_filterer/sync.rs
+++ b/tests/vendor_filterer/sync.rs
@@ -256,10 +256,10 @@ fn filter_without_manifest_path() {
     )
     .unwrap();
     write_file_create_parents(&dep_a, "src/lib.rs", "").unwrap();
-    assert!(std::env::set_current_dir(&dep_a).is_ok());
     let output_folder = test_folder.join("vendor");
     let output = vendor(VendorOptions {
         output: Some(&output_folder),
+        current_dir: Some(&dep_a),
         ..Default::default()
     })
     .unwrap();
@@ -300,11 +300,11 @@ fn filter_without_manifest_but_sync() {
     )
     .unwrap();
     write_file_create_parents(&dep_b, "src/lib.rs", "").unwrap();
-    assert!(std::env::set_current_dir(&dep_a).is_ok());
     let output_folder = test_folder.join("vendor");
     let output = vendor(VendorOptions {
         output: Some(&output_folder),
         sync: vec![&manifest_b],
+        current_dir: Some(&dep_a),
         ..Default::default()
     })
     .unwrap();


### PR DESCRIPTION
Even though two sync tests rely on specific working directory for vendoring invocation, they were executed in wrong directory despite changing it before vendor() invocation. That's because vendor() always resets working directory to project_root().

Allow customization of working directory through VendorOptions and use it in filter_without_manifest_path and filter_without_manifest_but_sync tests.