### PR TITLE
fix: exclude-crate-path resolution with --versioned-dirs active

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,11 +452,12 @@ fn find_glob_matches(base_path: &Utf8Path, pattern: &str) -> Result<Vec<Utf8Path
 }
 
 /// Given a crate, remove matching files/directories in excludes.
-fn process_excludes(path: &Utf8PathBuf, name: &str, excludes: &HashSet<&str>) -> Result<()> {
+fn process_excludes(path: &Utf8PathBuf, name: &str, excludes: &HashSet<String>) -> Result<()> {
     let mut matched = false;
     let mut removed_patterns = Vec::new();
 
-    for &exclude in excludes.iter() {
+    for exclude in excludes.iter() {
+        let exclude = exclude.as_str();
         if Utf8Path::new(exclude).is_absolute() {
             anyhow::bail!("Invalid absolute path in crate exclude {name} {exclude}");
         }
@@ -870,7 +871,7 @@ fn expand_platforms<'b>(
 fn delete_unreferenced_packages(
     output_dir: &Utf8Path,
     package_filenames: &BTreeMap<Cow<'_, str>, &Package>,
-    excludes: &HashMap<&str, HashSet<&str>>,
+    excludes: &HashMap<String, HashSet<String>>,
 ) -> Result<()> {
     // A reusable buffer (silly optimization to avoid allocating lots of path buffers)
     let mut pbuf = Utf8PathBuf::from(&output_dir);
@@ -1043,36 +1044,49 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
+    // Build a one-time reverse index from bare crate name to the vendor directory name(s)
+    // on disk.  With --versioned-dirs a crate can appear in multiple directories (e.g.
+    // "hex-0.3.2" and "hex-0.4.3"); without it the highest version uses the plain name.
+    // package_filenames is already keyed by those exact directory names.
+    let mut crate_to_dirs: HashMap<&str, Vec<&str>> = HashMap::new();
+    for (dir_name, pkg) in &package_filenames {
+        crate_to_dirs
+            .entry(pkg.name.as_ref())
+            .or_default()
+            .push(dir_name.as_ref());
+    }
+
     // Index the excludes into a mapping from vendor directory name -> [list of excludes].
     // We key by the actual directory name on disk (e.g. "hex-0.4.3" with --versioned-dirs,
     // or "hex" without) rather than the bare crate name, so that the lookup in
     // delete_unreferenced_packages() matches correctly regardless of --versioned-dirs.
-    let mut excludes: HashMap<&str, HashSet<&str>> = HashMap::new();
+    // The map owns its data to avoid lifetime coupling to package_filenames or config.
+    let mut excludes: HashMap<String, HashSet<String>> = HashMap::new();
     if let Some(exclude_paths) = &config.exclude_crate_paths {
         for ex_path in exclude_paths {
             if ex_path.name == "*" {
                 // Wildcard: kept as-is; delete_unreferenced_packages handles it separately.
-                let e = excludes.entry("*").or_default();
-                e.insert(ex_path.exclude.as_str());
+                excludes
+                    .entry("*".to_string())
+                    .or_default()
+                    .insert(ex_path.exclude.clone());
             } else {
-                // Resolve the bare crate name to the actual directory name(s) that cargo
-                // vendor placed on disk.  With --versioned-dirs a crate can have multiple
-                // versioned directories (e.g. "hex-0.3.2" and "hex-0.4.3"); without it the
-                // highest version uses the plain name.  package_filenames is already keyed by
-                // those exact directory names, so we iterate it to find matches.
-                let mut matched = false;
-                for (dir_name, pkg) in &package_filenames {
-                    if pkg.name == ex_path.name {
-                        let e = excludes.entry(dir_name.as_ref()).or_default();
-                        e.insert(ex_path.exclude.as_str());
-                        matched = true;
+                // Resolve the bare crate name via the reverse index built above.
+                match crate_to_dirs.get(ex_path.name.as_str()) {
+                    Some(dir_names) => {
+                        for &dir_name in dir_names {
+                            excludes
+                                .entry(dir_name.to_string())
+                                .or_default()
+                                .insert(ex_path.exclude.clone());
+                        }
                     }
-                }
-                if !matched {
-                    eprintln!(
-                        "Warning: --exclude-crate-path specifies unknown crate '{}'",
-                        ex_path.name
-                    );
+                    None => {
+                        eprintln!(
+                            "Warning: --exclude-crate-path specifies unknown crate '{}'",
+                            ex_path.name
+                        );
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1043,12 +1043,38 @@ pub fn run(args: Args) -> Result<()> {
         }
     }
 
-    // Index the excludes into a mapping from crate name -> [list of excludes].
+    // Index the excludes into a mapping from vendor directory name -> [list of excludes].
+    // We key by the actual directory name on disk (e.g. "hex-0.4.3" with --versioned-dirs,
+    // or "hex" without) rather than the bare crate name, so that the lookup in
+    // delete_unreferenced_packages() matches correctly regardless of --versioned-dirs.
     let mut excludes: HashMap<&str, HashSet<&str>> = HashMap::new();
     if let Some(exclude_paths) = &config.exclude_crate_paths {
         for ex_path in exclude_paths {
-            let e = excludes.entry(ex_path.name.as_str()).or_default();
-            e.insert(ex_path.exclude.as_str());
+            if ex_path.name == "*" {
+                // Wildcard: kept as-is; delete_unreferenced_packages handles it separately.
+                let e = excludes.entry("*").or_default();
+                e.insert(ex_path.exclude.as_str());
+            } else {
+                // Resolve the bare crate name to the actual directory name(s) that cargo
+                // vendor placed on disk.  With --versioned-dirs a crate can have multiple
+                // versioned directories (e.g. "hex-0.3.2" and "hex-0.4.3"); without it the
+                // highest version uses the plain name.  package_filenames is already keyed by
+                // those exact directory names, so we iterate it to find matches.
+                let mut matched = false;
+                for (dir_name, pkg) in &package_filenames {
+                    if pkg.name == ex_path.name {
+                        let e = excludes.entry(dir_name.as_ref()).or_default();
+                        e.insert(ex_path.exclude.as_str());
+                        matched = true;
+                    }
+                }
+                if !matched {
+                    eprintln!(
+                        "Warning: --exclude-crate-path specifies unknown crate '{}'",
+                        ex_path.name
+                    );
+                }
+            }
         }
     }
 

--- a/tests/vendor_filterer/exclude.rs
+++ b/tests/vendor_filterer/exclude.rs
@@ -77,6 +77,7 @@ fn exclude_with_glob_patterns() {
 /// name supplied by the user (e.g. `hex#benches`) and resolve it to the versioned directory
 /// name on disk (e.g. `hex-0.4.3`).
 #[test]
+#[serial_test::parallel]
 fn exclude_with_versioned_dirs_single_version() {
     let (_td, test_folder) = tempdir().unwrap();
     let manifest = write_file_create_parents(
@@ -114,6 +115,7 @@ fn exclude_with_versioned_dirs_single_version() {
 
 /// Same as above but with two versions of the same crate to exercise the multi-version path.
 #[test]
+#[serial_test::parallel]
 fn exclude_with_versioned_dirs_multiple_versions() {
     let (_td, test_folder) = tempdir().unwrap();
     let dep_a = test_folder.join("A");

--- a/tests/vendor_filterer/exclude.rs
+++ b/tests/vendor_filterer/exclude.rs
@@ -1,4 +1,4 @@
-use super::common::{tempdir, vendor, verify_no_windows, VendorOptions};
+use super::common::{tempdir, vendor, verify_no_windows, write_file_create_parents, VendorOptions};
 
 #[test]
 #[serial_test::parallel]
@@ -67,5 +67,103 @@ fn exclude_with_glob_patterns() {
                 assert!(entry.path().extension() != Some("c"));
             }
         }
+    }
+}
+
+/// Regression test: --exclude-crate-path must work when --versioned-dirs is also active.
+///
+/// With --versioned-dirs, cargo vendor names directories as `<name>-<version>` even when there
+/// is only one version of a crate.  The exclude lookup must still match against the bare crate
+/// name supplied by the user (e.g. `hex#benches`) and resolve it to the versioned directory
+/// name on disk (e.g. `hex-0.4.3`).
+#[test]
+fn exclude_with_versioned_dirs_single_version() {
+    let (_td, test_folder) = tempdir().unwrap();
+    let manifest = write_file_create_parents(
+        &test_folder,
+        "Cargo.toml",
+        r#"
+        [package]
+        name = "foo"
+        version = "0.1.0"
+
+        [dependencies]
+        hex = "0.4.3"
+    "#,
+    )
+    .unwrap();
+    write_file_create_parents(&test_folder, "src/lib.rs", "").unwrap();
+    let output_folder = test_folder.join("vendor");
+    let output = vendor(VendorOptions {
+        output: Some(&output_folder),
+        manifest_path: Some(&manifest),
+        versioned_dirs: true,
+        exclude_crate_paths: Some(&["hex#benches"]),
+        ..Default::default()
+    })
+    .unwrap();
+    assert!(output.status.success());
+    // With --versioned-dirs the crate is under hex-0.4.3/, not hex/
+    let hex_dir = output_folder.join("hex-0.4.3");
+    assert!(hex_dir.exists(), "hex-0.4.3 directory should exist");
+    assert!(
+        !hex_dir.join("benches").exists(),
+        "hex-0.4.3/benches should have been excluded"
+    );
+}
+
+/// Same as above but with two versions of the same crate to exercise the multi-version path.
+#[test]
+fn exclude_with_versioned_dirs_multiple_versions() {
+    let (_td, test_folder) = tempdir().unwrap();
+    let dep_a = test_folder.join("A");
+    let dep_b = test_folder.join("B");
+    let manifest_a = write_file_create_parents(
+        &dep_a,
+        "Cargo.toml",
+        r#"
+        [package]
+        name = "foo"
+        version = "0.1.0"
+
+        [dependencies]
+        hex = "0.4.3"
+        bar = { path="../B/" }
+    "#,
+    )
+    .unwrap();
+    write_file_create_parents(&dep_a, "src/lib.rs", "").unwrap();
+    write_file_create_parents(
+        &dep_b,
+        "Cargo.toml",
+        r#"
+        [package]
+        name = "bar"
+        version = "0.1.0"
+
+        [dependencies]
+        hex = "0.3.2"
+    "#,
+    )
+    .unwrap();
+    write_file_create_parents(&dep_b, "src/lib.rs", "").unwrap();
+    let output_folder = test_folder.join("vendor");
+    let output = vendor(VendorOptions {
+        output: Some(&output_folder),
+        manifest_path: Some(&manifest_a),
+        versioned_dirs: true,
+        exclude_crate_paths: Some(&["hex#benches"]),
+        ..Default::default()
+    })
+    .unwrap();
+    assert!(output.status.success());
+    // Both versioned hex directories should exist and have benches excluded.
+    for hex_dir_name in &["hex-0.4.3", "hex-0.3.2"] {
+        let hex_dir = output_folder.join(hex_dir_name);
+        assert!(hex_dir.exists(), "{hex_dir_name} directory should exist");
+        assert!(
+            !hex_dir.join("benches").exists(),
+            "{hex_dir_name}/benches should have been excluded"
+        );
     }
 }


### PR DESCRIPTION
When --versioned-dirs is active, cargo vendor names directories as `<name>-<version>` (e.g. `hex-0.4.3`) instead of just the bare crate name. The exclude lookup was keyed by bare crate name, so it never matched and the specified paths were silently left in place.

Fix by resolving each bare crate name in --exclude-crate-path to the actual directory name(s) on disk using the existing package_filenames map (which is already keyed by the on-disk directory name). Wildcard entries (`*`) are preserved as-is. An unknown crate name now emits a warning instead of silently doing nothing.

Adds two regression tests covering the single-version and multi-version cases with --versioned-dirs.